### PR TITLE
fix initial_lr is not specified in param_groups[0] when reuming

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -113,7 +113,7 @@ def main():
         model.half()
         criterion.half()
 
-    optimizer = torch.optim.SGD(model.parameters(), args.lr,
+    optimizer = torch.optim.SGD([{"params":model.parameters(),"initial_lr":args.lr}], lr=args.lr,
                                 momentum=args.momentum,
                                 weight_decay=args.weight_decay)
 


### PR DESCRIPTION
Hi, 

When I tried to resume the training process, I was told that `'initial_lr' is not specified in param_groups[0] when resuming an optimizer`. So, I guess we have to feed this key to the optimizer. That is:
```
optimizer = torch.optim.SGD([{"params":model.parameters(),"initial_lr":args.lr}], lr=args.lr,
                                momentum=args.momentum,
                                weight_decay=args.weight_decay)
```