### PR TITLE
Add parser argument to set LR milestone for training

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -55,6 +55,8 @@ parser.add_argument('--save-dir', dest='save_dir',
 parser.add_argument('--save-every', dest='save_every',
                     help='Saves checkpoints at every specified number of epochs',
                     type=int, default=10)
+parser.add_argument('--lr-milestones', default=[100, 150], nargs='+',
+                    help='list of epoch indices for multi step learning rate scheduler', type=int)
 best_prec1 = 0
 
 
@@ -116,9 +118,9 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), args.lr,
                                 momentum=args.momentum,
                                 weight_decay=args.weight_decay)
-
+    print(args.lr_milestones)
     lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer,
-                                                        milestones=[100, 150], last_epoch=args.start_epoch - 1)
+                                                        milestones=args.lr_milestones, last_epoch=args.start_epoch - 1)
 
     if args.arch in ['resnet1202', 'resnet110']:
         # for resnet1202 original paper uses lr=0.01 for first 400 minibatches for warm-up

--- a/trainer.py
+++ b/trainer.py
@@ -87,8 +87,8 @@ def main():
 
     cudnn.benchmark = True
 
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                     std=[0.229, 0.224, 0.225])
+    normalize = transforms.Normalize(mean=[0.4914, 0.4822, 0.4465], #[0.485, 0.456, 0.406],
+                                     std=[0.247, 0.243, 0.261])#[0.229, 0.224, 0.225])
 
     train_loader = torch.utils.data.DataLoader(
         datasets.CIFAR10(root='./data', train=True, transform=transforms.Compose([

--- a/trainer.py
+++ b/trainer.py
@@ -118,7 +118,7 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), args.lr,
                                 momentum=args.momentum,
                                 weight_decay=args.weight_decay)
-    print(args.lr_milestones)
+
     lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer,
                                                         milestones=args.lr_milestones, last_epoch=args.start_epoch - 1)
 


### PR DESCRIPTION
When training with a different number of epochs it makes sense to adjust the LR schedule. 
See my comment in the discussion [About the number of epochs?](https://github.com/akamaster/pytorch_resnet_cifar10/issues/29#issuecomment-1489853255). 