### PR TITLE
update mean and std of cifar dataset

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -85,8 +85,9 @@ def main():
 
     cudnn.benchmark = True
 
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                     std=[0.229, 0.224, 0.225])
+    normalize = transforms.Normalize(mean=[0.4914, 0.4822, 0.4465],
+                                     std=[0.247, 0.243, 0.261])
+
 
     train_loader = torch.utils.data.DataLoader(
         datasets.CIFAR10(root='./data', train=True, transform=transforms.Compose([


### PR DESCRIPTION
The previous normalization values for CIFAR-10 seem to be wrong. 

Source: [Correct Normalization Values for CIFAR-10](https://github.com/kuangliu/pytorch-cifar/issues/19#issue-268972488)

The given models need to be re-run to get updated results (performance). 